### PR TITLE
Improve citation matching

### DIFF
--- a/dtk.el
+++ b/dtk.el
@@ -25,6 +25,7 @@
 (require 's)
 (require 'seq)
 (require 'subr-x)
+(require 'rx)
 
 ;;;; Customization
 ;; User configurable variables:
@@ -118,6 +119,32 @@ thing made that was made."
 (defconst dtk-books-regexp
   (regexp-opt dtk-books)
   "Regular expression aiming to match a member of DTK-BOOKS.")
+;; Regexps to match citation.
+;;
+;; This works for single verse as well as verse range expression, i.e,
+;; Genesis 10:10 and Matthew 2:1-10 will both work.
+;;
+;; Three groups are Book, Chapter, and Verse/Range (Optional) respectively. Note
+;; that user Verse/Range is optional, as sometimes the whole chapter is needed,
+;; e.g: Luke 3.
+;;
+;; `rx-to-string' usage is referred from:
+;; https://emacs.stackexchange.com/questions/2288/how-do-i-create-a-dynamic-regexp-with-rx
+(defconst dtk-citation-regexp
+  (rx-to-string
+   `(sequence
+     ;; Group 1: Book
+     (group (sequence symbol-start (or ,@dtk-books) symbol-end))
+     space
+     ;; Group 2: Chapter
+     (group (one-or-more digit))
+     ;; Group 3: Verse or Verse range
+     ;; Note this is optional, meaning that the whole chapter is needed.
+     (optional
+      ":"
+      (group (one-or-more digit) (opt "-" (one-or-more digit)))))
+   )
+  "Regular expression to match a citation.")
 
 ;;; Functions
 ;;;###autoload


### PR DESCRIPTION
Hi @thomp , how's it going? It's been a while and I wish all is well with you. 

These days I'm thinking to improve upon citation matching. I believe this may involve some code changes to you so I'd like to discuss. 

The idea is to come up with functions that help us identify format such as "Matthew 1:10", "Luke 1:10-20", "Genesis 3", etc. To do this I studied a bit on regular expression in Emacs, the main result is a regexp called `dtk-citation-regexp` that help to detect book/chapter/verse/verse-range. You may test with:

```
(s-match-strings-all
 dtk-citation-regexp
 "Testing citation between Matthew 2:45-56 or Genesis 23:34 or Luke 3.")
```

Based on it, I rewrote `dtk-parse-citation-at-point`. While there are still some edge cases, it works pretty well over my test buffer:

```
Randomtest (Genesis 1:1;)
Matthew 2:23-24
Not-Exist 3:234
Genesis 1:3
Something bewtewewn ssfs Matthew 3:23-23
```

The main benefit being that user can put point somewhere within the citation and it should work as expected. There are still restrictions though: the citation cannot cross between 2 lines. But I suppose it's not a major case. 

Your input will be appreciated. 